### PR TITLE
Bump Survicate iOS SDK to 8.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["survicate-uxcam-integration"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/Survicate/survicate-ios-sdk", from: "7.0.0"),
+        .package(url: "https://github.com/Survicate/survicate-ios-sdk", from: "8.0.0"),
         .package(url: "https://github.com/uxcam/ios-sdk", from: "3.6.0"),
     ],
     targets: [

--- a/survicate-uxcam-integration.podspec
+++ b/survicate-uxcam-integration.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'survicate-uxcam-integration'
-  s.version          = '1.3.0'
+  s.version          = '1.4.0'
   s.summary          = 'Survicate UXCam Integration'
   s.description      = <<-DESC
   A thin library designed for seamless integration between Survicate and UXCam on iOS. It automatically sends survey answers coming from Survicate SDK as UXCam events that can be previewed directly in the UXCam panel.
@@ -18,9 +18,9 @@ Pod::Spec.new do |s|
   s.homepage          	= "https://survicate.com"
   s.author            	= { "Survicate" => "hello@survicate.com" }
   s.source_files        = 'Sources/survicate-uxcam-integration/*'
-  s.source              = { :git => 'https://github.com/Survicate/survicate-uxcam-integration-ios.git', :tag => '1.3.0' }
+  s.source              = { :git => 'https://github.com/Survicate/survicate-uxcam-integration-ios.git', :tag => '1.4.0' }
   s.static_framework    = true
 
   s.dependency 'UXCam'
-  s.dependency 'Survicate', '~> 7.0'
+  s.dependency 'Survicate', '~> 8.0'
 end


### PR DESCRIPTION
Bump Survicate iOS SDK from 7.0.0 to 8.0.0

Updates:
- Package.swift: dependency from 7.0.0 to 8.0.0
- podspec version: 1.3.0 → 1.4.0
- podspec source tag: 1.3.0 → 1.4.0
- podspec Survicate dependency: ~> 7.0 → ~> 8.0